### PR TITLE
Create separate login and profile pages

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react'
+import { ethers } from 'ethers'
+import { useMetaMask } from '../hooks/useMetaMask'
+import { getNonce, login as loginApi } from '../services/auth'
+import axios from 'axios'
+import { Button } from '../components/ui/button'
+import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card'
+
+interface LoginProps {
+  onSuccess: (token: string) => void
+}
+
+export default function Login({ onSuccess }: LoginProps) {
+  const { address, error, connect, isMetaMaskInstalled } = useMetaMask()
+  const [loading, setLoading] = useState(false)
+  const [loginError, setLoginError] = useState<string | null>(null)
+
+  const handleLogin = async () => {
+    if (!address) return
+    setLoading(true)
+    setLoginError(null)
+    try {
+      const nonce = await getNonce(address)
+      const provider = new ethers.BrowserProvider(window.ethereum)
+      const signer = await provider.getSigner()
+      const signature = await signer.signMessage(nonce)
+      const accessToken = await loginApi(address, signature)
+      localStorage.setItem('access_token', accessToken)
+      axios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`
+      onSuccess(accessToken)
+    } catch (err: any) {
+      setLoginError(err.response?.data?.message || err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Connexion Web3</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {!isMetaMaskInstalled() && (
+          <p className="text-red-600">
+            MetaMask non installé !{' '}
+            <a href="https://metamask.io/" target="_blank" rel="noopener">
+              Installer MetaMask
+            </a>
+          </p>
+        )}
+        {error && <p className="text-red-600">{error}</p>}
+        {!address ? (
+          <Button onClick={connect}>Se connecter avec MetaMask</Button>
+        ) : (
+          <p>
+            Adresse détectée : <code>{address}</code>
+          </p>
+        )}
+        {address && (
+          <Button onClick={handleLogin} disabled={loading}>
+            {loading ? 'Connexion…' : 'Se connecter'}
+          </Button>
+        )}
+        {loginError && <p className="text-red-600">{loginError}</p>}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react'
+import { fetchProfile } from '../services/profile'
+import { Button } from '../components/ui/button'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from '../components/ui/card'
+
+interface ProfileProps {
+  onLogout: () => void
+}
+
+export default function ProfilePage({ onLogout }: ProfileProps) {
+  const [profile, setProfile] = useState<{ address: string; message: string } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchProfile()
+      .then(data => setProfile(data))
+      .catch(err => setError(err.response?.data?.message || err.message))
+  }, [])
+
+  if (error) return <p className="text-red-600">Erreur : {error}</p>
+  if (!profile) return <p>Chargement du profil…</p>
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Mon profil Web3</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p>
+          🆔 Adresse : <code>{profile.address}</code>
+        </p>
+        <p>💬 Message : {profile.message}</p>
+      </CardContent>
+      <CardFooter>
+        <Button onClick={onLogout} className="w-full">
+          Déconnexion
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,4 +8,9 @@ export default defineConfig({
   plugins: [
     react(),
     tailwindcss()],
+    resolve: {
+      alias: {
+        '@': '/src',
+      },
+    },
 })


### PR DESCRIPTION
## Summary
- split login workflow into new pages
- show login page at `/login` and profile once authenticated
- add simple history-based router
- style pages with shadcn components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886b5aba5608321b9d34481ee78cc50